### PR TITLE
Fix backwards compatibility with using as `actor::run_actor`

### DIFF
--- a/src/actor.rs
+++ b/src/actor.rs
@@ -168,3 +168,7 @@ where
         requestor: Requestor(tx),
     }
 }
+
+/// Export `run` as `run_actor` for backwards compatibility
+#[allow(clippy::module_name_repetitions)]
+pub use run as run_actor;


### PR DESCRIPTION
There may be code that refers to `run_actor` as `actor::run_actor` which disappeared in the previous commit.  Fix that for backwards compatibility.