### PR TITLE
Deprecate `run_actor()`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 keywords = [ "async", "actor", "channel", "tokio" ]
 categories = [ "asynchronous", "concurrency"  ]
 license = "MIT OR Apache-2.0"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 rust-version = "1.63"
 

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -169,5 +169,16 @@ where
     }
 }
 
-/// Export `run` as `run_actor` for backwards compatibility
-pub use run as run_actor;
+/// A step implementation to trigger a deprecation warning when [`run_actor`]
+/// is used.  This basically is just effectively [`actor::run`] inlined.
+#[inline]
+#[allow(clippy::module_name_repetitions)]
+#[deprecated(since = "0.2.2", note = "Use `actor::run` instead")]
+pub fn run_actor<T>(actor: T, buffer: usize) -> Handle<T>
+where
+    T: Actor + Send,
+    <T as Actor>::Request: Send,
+    <T as Actor>::Response: Send,
+{
+    run(actor, buffer)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,8 @@ pub mod actor;
 /// Defines the error types that this crate provides.
 pub mod error;
 
-pub use actor::run as run_actor;
+#[allow(deprecated)]
+pub use actor::run_actor;
 pub use actor::{run, Actor, Handle, Requestor};
 pub use error::Error;
 


### PR DESCRIPTION
Use `actor::run()` instead and should function just the same. Current users would be warned that the function is deprecated but should be able to use it as-is.

It will be fully removed when we version up to v0.3.0.