### PR TITLE
Improve ergonomics of the actor interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ tokio = { version = "1.0", features = ["rt", "test-util", "tokio-macros", "macro
 unsafe_code = "forbid"
 
 [lints.clippy]
-pedantic = "deny"
-nursery = "deny"
+pedantic = { level = "deny", priority = -1 }
+nursery = { level = "deny", priority = -1 }
 unwrap_used = "deny"
 enum_glob_use = "deny"
 module_name_repetitions = "allow"

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ struct IntToString;
 impl Actor for IntToString {
     type Request = i32;
     type Response = String;
-    async fn handle(&mut self, request: Self::Request) -> Option<Self::Response> {
-        Some(request.to_string())
+    async fn handle(&mut self, request: Self::Request) -> Self::Response {
+        request.to_string()
     }
 }
 
@@ -43,10 +43,10 @@ async fn main() {
     let handle = actor::run(IntToString{}, 1);
 
     // Send a request to convert 5 to String.
-    let response = handle.requestor.request(5).await;
+    let response = handle.request(5).await;
 
     assert!(response.is_ok());
-    assert_eq!(response.unwrap(), Some(String::from("5")));
+    assert_eq!(response.unwrap(), String::from("5"));
 }
 
 ```

--- a/examples/car.rs
+++ b/examples/car.rs
@@ -41,12 +41,12 @@ impl Actor for Sedan {
     type Request = CarRequest;
     type Response = String;
 
-    async fn handle(&mut self, message: Self::Request) -> Option<Self::Response> {
+    async fn handle(&mut self, message: Self::Request) -> Self::Response {
         match message {
-            CarRequest::Park => Some(self.park().await),
-            CarRequest::Drive => Some(self.drive().await),
-            CarRequest::Brake => Some(self.brake().await),
-            CarRequest::Reverse => Some(self.reverse().await),
+            CarRequest::Park => self.park().await,
+            CarRequest::Drive => self.drive().await,
+            CarRequest::Brake => self.brake().await,
+            CarRequest::Reverse => self.reverse().await,
         }
     }
 }
@@ -80,12 +80,12 @@ impl Actor for Suv {
     type Request = CarRequest;
     type Response = String;
 
-    async fn handle(&mut self, message: Self::Request) -> Option<Self::Response> {
+    async fn handle(&mut self, message: Self::Request) -> Self::Response {
         match message {
-            CarRequest::Park => Some(self.park().await),
-            CarRequest::Drive => Some(self.drive().await),
-            CarRequest::Brake => Some(self.brake().await),
-            CarRequest::Reverse => Some(self.reverse().await),
+            CarRequest::Park => self.park().await,
+            CarRequest::Drive => self.drive().await,
+            CarRequest::Brake => self.brake().await,
+            CarRequest::Reverse => self.reverse().await,
         }
     }
 }
@@ -105,19 +105,18 @@ where
     <T as Actor>::Response: Send + Sync,
 {
     let actor_handle = actor::run(car, 1);
-    let requestor = actor_handle.requestor;
 
-    let response = requestor.request(CarRequest::Park).await.unwrap();
-    println!("{}", response.unwrap());
+    let response = actor_handle.request(CarRequest::Park).await.unwrap();
+    println!("{}", response);
 
-    let response = requestor.request(CarRequest::Drive).await.unwrap();
-    println!("{}", response.unwrap());
+    let response = actor_handle.request(CarRequest::Drive).await.unwrap();
+    println!("{}", response);
 
-    let response = requestor.request(CarRequest::Brake).await.unwrap();
-    println!("{}", response.unwrap());
+    let response = actor_handle.request(CarRequest::Brake).await.unwrap();
+    println!("{}", response);
 
-    let response = requestor.request(CarRequest::Reverse).await.unwrap();
-    println!("{}", response.unwrap());
+    let response = actor_handle.request(CarRequest::Reverse).await.unwrap();
+    println!("{}", response);
 }
 
 #[tokio::main(flavor = "current_thread")]

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -10,18 +10,18 @@ use tokio::{
 
 use crate::error::Error;
 
-/// This is returned by the [`Requestor::request`] method to indicate the result of the request.
-pub type RequestResult<Rsp> = Result<Option<Rsp>, Error>;
+/// This is returned by the [`Addr::request`] method to indicate the result of the request.
+pub type RequestResult<Rsp> = Result<Rsp, Error>;
 
-type OptionalResponder<Rsp> = Option<oneshot::Sender<Option<Rsp>>>;
+type OptionalResponder<Rsp> = Option<oneshot::Sender<Rsp>>;
 
-/// A [Requestor] can be passed around by cloning it so multiple requestors can send
+/// An [Addr] can be passed around by cloning it so multiple requestors can send
 /// requests to the [Actor]
 #[repr(transparent)]
 #[derive(Debug)]
-pub struct Requestor<Req, Rsp>(mpsc::Sender<(Req, OptionalResponder<Rsp>)>);
+pub struct Addr<Req, Rsp>(mpsc::Sender<(Req, OptionalResponder<Rsp>)>);
 
-impl<Req, Rsp> Clone for Requestor<Req, Rsp>
+impl<Req, Rsp> Clone for Addr<Req, Rsp>
 where
     Req: Send,
 {
@@ -30,7 +30,7 @@ where
     }
 }
 
-impl<Req, Rsp> ops::Deref for Requestor<Req, Rsp> {
+impl<Req, Rsp> ops::Deref for Addr<Req, Rsp> {
     type Target = mpsc::Sender<(Req, OptionalResponder<Rsp>)>;
 
     fn deref(&self) -> &Self::Target {
@@ -38,7 +38,7 @@ impl<Req, Rsp> ops::Deref for Requestor<Req, Rsp> {
     }
 }
 
-impl<Req, Rsp> Requestor<Req, Rsp>
+impl<Req, Rsp> Addr<Req, Rsp>
 where
     Req: Send + 'static,
     Rsp: Send + 'static,
@@ -52,7 +52,7 @@ where
     /// - `Error::RequestError`: Problem with sending the request
     /// - `Error::ResponseError`: Problem with receiving the response
     pub async fn request(&self, request: Req) -> RequestResult<Rsp> {
-        let (rsp_tx, rsp_rx) = oneshot::channel::<Option<Rsp>>();
+        let (rsp_tx, rsp_rx) = oneshot::channel::<Rsp>();
         self.0
             .send((request, Some(rsp_tx)))
             .await
@@ -62,23 +62,18 @@ where
     }
 
     /// Sends an event to the [`Actor`] instance and does not wait for a response.
-    /// `send_event` returns a `JoinHandle` to allow the caller the option to wait for the event to be
-    /// sent.  Typically, you don't have to...
     /// NOTE: An event is still a [`Actor::Request`] type.
-    pub fn send_event(&self, event: Req) -> JoinHandle<Result<(), Error>> {
-        let sender = self.0.clone();
-        tokio::spawn(async move {
-            sender
-                .send((event, None))
-                .await
-                .map_err(|_e| Error::EventError)
-        })
+    pub async fn event(&self, event: Req) -> Result<(), Error> {
+        self.0
+            .send((event, None))
+            .await
+            .map_err(|_e| Error::EventError)
     }
 }
 
 /// This is a handle to the spawned [Actor] instance via [`actor::run`].  This enables the owner of the
 /// `Handle<T>` to abort or wait for the `Actor` spawned instance.
-/// It also contains a `requestor` field that can be cloned and passed around to allow multiple
+/// It also contains an `addr` field that can be cloned and passed around to allow multiple
 /// clients to send requests to the `Actor`.
 pub struct Handle<T>
 where
@@ -86,8 +81,8 @@ where
     <T as Actor>::Request: Send,
     <T as Actor>::Response: Send,
 {
-    /// A clonable `Requestor` for use in sending requests and events to the `Actor`
-    pub requestor: Requestor<<T as Actor>::Request, <T as Actor>::Response>,
+    /// A clonable `Addr` for use in sending requests and events to the `Actor`
+    pub addr: Addr<<T as Actor>::Request, <T as Actor>::Response>,
     /// The tokio JoinHandle to control the spawned task that runs the `Actor`
     pub handle: JoinHandle<()>,
 }
@@ -100,9 +95,22 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Handle")
-            .field("requestor", &self.requestor)
+            .field("addr", &self.addr)
             .field("handle", &self.handle)
             .finish()
+    }
+}
+
+impl<T> ops::Deref for Handle<T>
+where
+    T: Actor + Send,
+    <T as Actor>::Request: Send,
+    <T as Actor>::Response: Send,
+{
+    type Target = Addr<<T as Actor>::Request, <T as Actor>::Response>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.addr
     }
 }
 
@@ -127,14 +135,19 @@ where
 #[async_trait]
 pub trait Actor: Send + 'static {
     /// The type of the request that the `Actor` could process.
-    type Request;
+    type Request: Send;
 
     /// The type of the response that the `Actor` would return
-    type Response;
+    type Response: Send;
 
-    /// Method to handle the `Request` and expects to return an optional response.
-    /// Return None if there really is a reason or data to return the requestor
-    async fn handle(&mut self, message: Self::Request) -> Option<Self::Response>;
+    /// Method to handle the `Request` and returns a response.
+    async fn handle(&mut self, message: Self::Request) -> Self::Response;
+
+    /// Method to handle events.  An event is a request that does not expect a response.
+    /// The default implementation calls `handle` and ignores the response.
+    async fn handle_event(&mut self, message: Self::Request) {
+        let _ = self.handle(message).await;
+    }
 }
 
 /// Spawns an [Actor] instance message handling loop.
@@ -156,15 +169,17 @@ where
 
     let handle = tokio::spawn(async move {
         while let Some((msg, rsp_tx)) = rx.recv().await {
-            let response = actor.handle(msg).await;
             if let Some(rsp_tx) = rsp_tx {
+                let response = actor.handle(msg).await;
                 let _ = rsp_tx.send(response);
+            } else {
+                actor.handle_event(msg).await;
             }
         }
     });
 
     Handle {
         handle,
-        requestor: Requestor(tx),
+        addr: Addr(tx),
     }
 }

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -63,6 +63,9 @@ where
 
     /// Sends an event to the [`Actor`] instance and does not wait for a response.
     /// NOTE: An event is still a [`Actor::Request`] type.
+    ///
+    /// # Errors
+    /// - `Error::EventError`: Problem with sending the event
     pub async fn event(&self, event: Req) -> Result<(), Error> {
         self.0
             .send((event, None))
@@ -71,8 +74,9 @@ where
     }
 }
 
-/// This is a handle to the spawned [Actor] instance via [`actor::run`].  This enables the owner of the
-/// `Handle<T>` to abort or wait for the `Actor` spawned instance.
+/// This is a handle to the spawned [Actor] instance via [`actor::run`].
+///
+/// This enables the owner of the `Handle<T>` to abort or wait for the `Actor` spawned instance.
 /// It also contains an `addr` field that can be cloned and passed around to allow multiple
 /// clients to send requests to the `Actor`.
 pub struct Handle<T>
@@ -83,7 +87,7 @@ where
 {
     /// A clonable `Addr` for use in sending requests and events to the `Actor`
     pub addr: Addr<<T as Actor>::Request, <T as Actor>::Response>,
-    /// The tokio JoinHandle to control the spawned task that runs the `Actor`
+    /// The tokio `JoinHandle` to control the spawned task that runs the `Actor`
     pub handle: JoinHandle<()>,
 }
 
@@ -151,6 +155,7 @@ pub trait Actor: Send + 'static {
 }
 
 /// Spawns an [Actor] instance message handling loop.
+///
 /// It accepts an `actor` that implements an [Actor] trait.
 /// `buffer` is the number of messages that can be kept in the channel.  Typically, you would only
 /// need 1 but if the `Actor` takes a long time to process, a bigger buffer may be needed.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,8 @@
 //! impl Actor for IntToString {
 //!    type Request = i32;
 //!    type Response = String;
-//!    async fn handle(&mut self, request: Self::Request) -> Option<Self::Response> {
-//!        Some(request.to_string())
+//!    async fn handle(&mut self, request: Self::Request) -> Self::Response {
+//!        request.to_string()
 //!    }
 //! }
 //!
@@ -29,10 +29,10 @@
 //!    let handle = atticus::actor::run(IntToString{}, 1);
 //!
 //!    // Send a request to convert 5 to String.
-//!    let response = handle.requestor.request(5).await;
+//!    let response = handle.request(5).await;
 //!
 //!    assert!(response.is_ok());
-//!    assert_eq!(response.unwrap(), Some(String::from("5")));
+//!    assert_eq!(response.unwrap(), String::from("5"));
 //! }
 //!
 //! ```
@@ -46,7 +46,7 @@ pub mod actor;
 /// Defines the error types that this crate provides.
 pub mod error;
 
-pub use actor::{run, Actor, Handle, Requestor};
+pub use actor::{run, Actor, Addr, Handle};
 pub use error::Error;
 
 /// Re-export tokio symbols that we use
@@ -67,7 +67,7 @@ mod tests {
         type Request = usize;
         type Response = bool;
 
-        async fn handle(&mut self, _message: Self::Request) -> Option<Self::Response> {
+        async fn handle(&mut self, _message: Self::Request) -> Self::Response {
             unreachable!()
         }
     }
@@ -77,14 +77,14 @@ mod tests {
 
     #[test]
     const fn test_public_types() {
-        is_send_sync::<Requestor<NormalType, NormalType>>();
+        is_send_sync::<Addr<NormalType, NormalType>>();
         is_send_sync::<Handle<NormalType>>();
         is_send_sync::<Error>();
     }
 
     #[test]
     const fn test_impls_debug() {
-        impls_or_derives_debug::<Requestor<NormalType, NormalType>>();
+        impls_or_derives_debug::<Addr<NormalType, NormalType>>();
         impls_or_derives_debug::<Handle<NormalType>>();
         impls_or_derives_debug::<Error>();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ mod tests {
         type Response = bool;
 
         async fn handle(&mut self, _message: Self::Request) -> Self::Response {
-            unreachable!()
+            true
         }
     }
 

--- a/tests/abort_join.rs
+++ b/tests/abort_join.rs
@@ -17,7 +17,7 @@ mod abort_join {
 
         actor_handle.abort();
 
-        let response = actor_handle.requestor.request(Message::IgnoreThis).await;
+        let response = actor_handle.request(Message::IgnoreThis).await;
 
         assert!(response.is_err());
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -20,6 +20,7 @@ pub enum ResponseMsg {
     Echo(String),
     Number(i32),
     LastRequest(Option<Message>),
+    None,
 }
 
 #[async_trait]
@@ -27,16 +28,16 @@ impl Actor for TestActor {
     type Request = Message;
     type Response = ResponseMsg;
 
-    async fn handle(&mut self, message: Self::Request) -> Option<Self::Response> {
+    async fn handle(&mut self, message: Self::Request) -> Self::Response {
         use Message::*;
 
         println!("handling message");
 
         let response = match &message {
-            Echo(s) => Some(ResponseMsg::Echo(s.clone())),
-            AddOne(i) => Some(ResponseMsg::Number(i + 1)),
-            IgnoreThis => None,
-            GetLastRequest => Some(ResponseMsg::LastRequest(self.last_message.clone())),
+            Echo(s) => ResponseMsg::Echo(s.clone()),
+            AddOne(i) => ResponseMsg::Number(i + 1),
+            IgnoreThis => ResponseMsg::None,
+            GetLastRequest => ResponseMsg::LastRequest(self.last_message.clone()),
         };
 
         self.last_message = Some(message);

--- a/tests/request.rs
+++ b/tests/request.rs
@@ -9,11 +9,10 @@ mod request {
     async fn echo() {
         let actor_handle = actor::run(TestActor::default(), 1);
         let response = actor_handle
-            .requestor
             .request(Message::Echo("ping".to_owned()))
             .await
             .unwrap();
-        assert_eq!(response.unwrap(), ResponseMsg::Echo("ping".to_owned()));
+        assert_eq!(response, ResponseMsg::Echo("ping".to_owned()));
     }
 
     #[tokio::test]
@@ -21,22 +20,20 @@ mod request {
         const NUMBER: i32 = 6;
         let actor_handle = actor::run(TestActor::default(), 1);
         let response = actor_handle
-            .requestor
             .request(Message::AddOne(NUMBER))
             .await
             .unwrap();
-        assert_eq!(response.unwrap(), ResponseMsg::Number(NUMBER + 1));
+        assert_eq!(response, ResponseMsg::Number(NUMBER + 1));
     }
 
     #[tokio::test]
     async fn respond_with_none() {
         let actor_handle = actor::run(TestActor::default(), 1);
         let response = actor_handle
-            .requestor
             .request(Message::IgnoreThis)
             .await
             .unwrap();
-        assert_eq!(response, None);
+        assert_eq!(response, ResponseMsg::None);
     }
 
     #[tokio::test]
@@ -44,39 +41,32 @@ mod request {
         const NUMBER: i32 = 6;
         let actor_handle = actor::run(TestActor::default(), 1);
 
-        let requestor2 = actor_handle.requestor.clone();
+        let requestor2 = actor_handle.addr.clone();
 
         let req2 =
             tokio::spawn(async move { requestor2.request(Message::AddOne(NUMBER)).await.unwrap() });
 
         let response = actor_handle
-            .requestor
             .request(Message::Echo("ping!".to_string()))
             .await
             .unwrap();
 
-        assert_eq!(response, Some(ResponseMsg::Echo("ping!".to_string())));
-        assert_eq!(req2.await.unwrap(), Some(ResponseMsg::Number(7)));
+        assert_eq!(response, ResponseMsg::Echo("ping!".to_string()));
+        assert_eq!(req2.await.unwrap(), ResponseMsg::Number(7));
     }
 
     #[tokio::test]
     async fn send_an_event() {
         let actor_handle = actor::run(TestActor::default(), 1);
-        let event_task_handle = actor_handle.requestor.send_event(Message::IgnoreThis);
-
-        // Let's do an await here to make sure that the actor has received the event before
-        // proceding with the next request.
-        // In actual practice, this is not really needed but may be used for niche cases.
-        event_task_handle.await.unwrap().unwrap();
+        actor_handle.event(Message::IgnoreThis).await.unwrap();
 
         let last_request = actor_handle
-            .requestor
             .request(Message::GetLastRequest)
             .await
             .unwrap();
 
         assert_eq!(
-            last_request.unwrap(),
+            last_request,
             ResponseMsg::LastRequest(Some(Message::IgnoreThis))
         );
     }

--- a/tests/request.rs
+++ b/tests/request.rs
@@ -19,20 +19,14 @@ mod request {
     async fn add_one() {
         const NUMBER: i32 = 6;
         let actor_handle = actor::run(TestActor::default(), 1);
-        let response = actor_handle
-            .request(Message::AddOne(NUMBER))
-            .await
-            .unwrap();
+        let response = actor_handle.request(Message::AddOne(NUMBER)).await.unwrap();
         assert_eq!(response, ResponseMsg::Number(NUMBER + 1));
     }
 
     #[tokio::test]
     async fn respond_with_none() {
         let actor_handle = actor::run(TestActor::default(), 1);
-        let response = actor_handle
-            .request(Message::IgnoreThis)
-            .await
-            .unwrap();
+        let response = actor_handle.request(Message::IgnoreThis).await.unwrap();
         assert_eq!(response, ResponseMsg::None);
     }
 
@@ -60,10 +54,7 @@ mod request {
         let actor_handle = actor::run(TestActor::default(), 1);
         actor_handle.event(Message::IgnoreThis).await.unwrap();
 
-        let last_request = actor_handle
-            .request(Message::GetLastRequest)
-            .await
-            .unwrap();
+        let last_request = actor_handle.request(Message::GetLastRequest).await.unwrap();
 
         assert_eq!(
             last_request,


### PR DESCRIPTION
The current interface of `atticus` had some ergonomic friction, specifically with the redundant `Option` in responses and the indirect way of sending requests. This PR introduces several breaking changes to improve the overall developer experience:

1. **Simplified Trait**: `Actor::handle` now returns `Self::Response`. Users wanting an optional response can use `Option<T>` as their response type.
2. **Standard Naming**: `Requestor` has been renamed to `Addr` (Address), which is more common in actor systems.
3. **Direct Handle Interaction**: `Handle` now implements `Deref` to `Addr`, allowing `handle.request(...)` instead of `handle.requestor.request(...)`.
4. **Improved Events**: `send_event` is now `event`, it's an `async` function that returns a `Result`, and it no longer spawns an internal task. This allows for proper backpressure.
5. **Event Specialization**: Added `handle_event` to the `Actor` trait for potentially more efficient processing of fire-and-forget messages.

These changes make the library much cleaner to use while maintaining its minimal footprint.

---
*PR created automatically by Jules for task [516491059319429342](https://jules.google.com/task/516491059319429342) started by @blinking8888*